### PR TITLE
feat: enhance project cards with previews

### DIFF
--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -10,13 +10,21 @@
 }
 
 *{box-sizing:border-box}
-html,body{height:100%}
+html{height:100%;scroll-behavior:smooth}
+body{height:100%}
 body{
   margin:0;
   font-family: "Manrope", ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial;
   color:var(--text);
   background:var(--bg);
   line-height:1.6;
+  opacity:0;
+  animation:fade-in .6s ease-in-out forwards;
+}
+
+@keyframes fade-in{
+  from{opacity:0}
+  to{opacity:1}
 }
 
 
@@ -188,11 +196,33 @@ h1{ font-size:clamp(32px,6vw,56px); line-height:1.1; margin:14px 0 10px }
 @media (max-width:900px){ .grid-3,.grid-2{grid-template-columns:1fr} }
 
 .card{
-  background:#fff; border:1px solid var(--line);
-  padding:20px; border-radius:18px; height:100%; box-shadow:var(--shadow)
+  background:#fff;
+  border:1px solid var(--line);
+  padding:20px;
+  border-radius:18px;
+  height:100%;
+  box-shadow:var(--shadow);
+  cursor:pointer;
+  transition:transform .3s ease, box-shadow .3s ease;
+}
+.card:hover,
+.card:focus-within,
+.card.expanded{
+  transform:scale(1.03);
+  box-shadow:0 12px 32px rgba(10,12,14,.12);
 }
 .card h3{margin:0 0 8px}
 .card p{margin:0;color:var(--muted)}
+.card .extra{
+  display:none;
+  margin-top:8px;
+  color:var(--text);
+}
+.card:hover .extra,
+.card.expanded .extra,
+.card:focus-within .extra{
+  display:block;
+}
 
 /* --- Organize photo with text overlay + fade --- */
 .organize-figure{

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -59,22 +59,27 @@ const content = `
   <div class="container">
     <h2>Past Projects</h2>
     <div class="grid grid-3">
-      <article class="card">
-        <img src="src/assets/images/project1.jpg" alt="Project 1">
-        <h3>Local Cafe Landing</h3>
-        <p>Mobile-first hero, sticky menu, and contact form — boosted calls and walk-ins.</p>
+      <article class="card" tabindex="0">
+        <a href="https://yondev.de" target="_blank" rel="noopener">
+          <img src="https://image.thum.io/get/https://yondev.de" alt="yondev.de preview">
+        </a>
+        <h3><a href="https://yondev.de" target="_blank" rel="noopener">Gonco Chicken</a></h3>
+        <p>Playful landing for a crispy chicken brand.</p>
+        <p class="extra">Built for quick browsing with bold visuals and smooth navigation.</p>
       </article>
-      <article class="card">
+      <article class="card" tabindex="0">
         <a href="https://ndnsanierung.de" target="_blank" rel="noopener">
-          <img src="src/assets/images/ndnsanierung.svg" alt="NDNSanierung project preview">
+          <img src="https://image.thum.io/get/https://ndnsanierung.de" alt="NDNSanierung.de preview">
         </a>
         <h3><a href="https://ndnsanierung.de" target="_blank" rel="noopener">NDNSanierung.de</a></h3>
-        <p>Renovation company portfolio featuring gallery and quick contact options.</p>
+        <p>Renovation specialist portfolio with gallery and contact.</p>
+        <p class="extra">Responsive showcase highlighting services, project imagery, and fast quote requests.</p>
       </article>
-      <article class="card">
+      <article class="card" tabindex="0">
         <img src="src/assets/images/project3.jpg" alt="Project 3">
         <h3>Artist Microsite</h3>
         <p>Lightweight page with embedded video, socials, and mailing list.</p>
+        <p class="extra">Designed for quick updates and easy fan engagement.</p>
       </article>
     </div>
   </div>
@@ -95,3 +100,7 @@ const content = `
 `;
 
 mountFrame(content, 'home');
+
+document.querySelectorAll('.card').forEach(card => {
+  card.addEventListener('click', () => card.classList.toggle('expanded'));
+});


### PR DESCRIPTION
## Summary
- add site-wide fade-in transitions and smooth scrolling
- pop project cards on hover/click with extra details and live site previews

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a34b99d7bc8321852986b2a12cdf57