### PR TITLE
feat: add dark mode toggle

### DIFF
--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -7,6 +7,21 @@
   --muted:#5c6672;
   --text:#101418;
   --shadow: 0 6px 24px rgba(10,12,14,.08);
+  --header-bg:rgba(255,255,255,.85);
+  --hover:#fafbfc;
+}
+
+[data-theme="dark"]{
+  --primary:#5f7044;
+  --accent:#ffcf40;
+  --bg:#0d1117;
+  --surface:#161b22;
+  --line:#30363d;
+  --muted:#8b949e;
+  --text:#f0f6fc;
+  --shadow:0 6px 24px rgba(0,0,0,.6);
+  --header-bg:rgba(22,27,34,.85);
+  --hover:#1f2328;
 }
 
 *{box-sizing:border-box}
@@ -37,7 +52,7 @@ img{max-width:100%;display:block}
   position:sticky;
   top:0;
   z-index:50;
-  background:rgba(255,255,255,.85);
+  background:var(--header-bg);
   backdrop-filter:saturate(140%) blur(8px);
   border-bottom:1px solid var(--line)
 }
@@ -97,10 +112,10 @@ img{max-width:100%;display:block}
 .menu-toggle{
   display:none; width:40px; height:36px;
   border:1px solid var(--line); border-radius:10px;
-  background:#fff; cursor:pointer; position:relative
+  background:var(--surface); cursor:pointer; position:relative
 }
 .menu-toggle span{
-  position:absolute; left:8px; right:8px; height:2px; background:#111
+  position:absolute; left:8px; right:8px; height:2px; background:var(--text)
 }
 .menu-toggle span:nth-child(1){top:10px}
 .menu-toggle span:nth-child(2){top:17px}
@@ -110,7 +125,7 @@ img{max-width:100%;display:block}
 .mobile-menu{
   position:absolute; right:0; top:64px;
   flex-direction:column; gap:10px;
-  background:#fff; border:1px solid var(--line);
+  background:var(--surface); border:1px solid var(--line);
   border-radius:14px; padding:12px; width:min(240px,80vw);
   box-shadow:0 16px 40px rgba(0,0,0,.14);
   display:none;
@@ -173,11 +188,11 @@ h1{ font-size:clamp(32px,6vw,56px); line-height:1.1; margin:14px 0 10px }
   display:inline-flex; align-items:center; gap:10px;
   padding:12px 16px; border-radius:14px;
   border:1px solid var(--line);
-  background:#fff; color:var(--text);
+  background:var(--surface); color:var(--text);
   box-shadow:var(--shadow); cursor:pointer; font-weight:600;
   transition:transform .15s ease, box-shadow .15s ease, background .15s ease
 }
-.btn:hover{ transform:translateY(-2px); box-shadow:0 12px 28px rgba(10,12,14,.12); background:#fafbfc }
+.btn:hover{ transform:translateY(-2px); box-shadow:0 12px 28px rgba(10,12,14,.12); background:var(--hover) }
 
 /* gold primary button */
 .btn.primary{
@@ -196,7 +211,7 @@ h1{ font-size:clamp(32px,6vw,56px); line-height:1.1; margin:14px 0 10px }
 @media (max-width:900px){ .grid-3,.grid-2{grid-template-columns:1fr} }
 
 .card{
-  background:#fff;
+  background:var(--surface);
   border:1px solid var(--line);
   padding:20px;
   border-radius:18px;
@@ -226,7 +241,7 @@ h1{ font-size:clamp(32px,6vw,56px); line-height:1.1; margin:14px 0 10px }
 
 /* --- Organize photo with text overlay + fade --- */
 .organize-figure{
-  position:relative; background:#fff; border:1px solid var(--line);
+  position:relative; background:var(--surface); border:1px solid var(--line);
   border-radius:18px; overflow:hidden; box-shadow:var(--shadow)
 }
 .organize-figure img{
@@ -252,7 +267,7 @@ h1{ font-size:clamp(32px,6vw,56px); line-height:1.1; margin:14px 0 10px }
 .eyebrow{
   display:inline-flex; align-items:center; gap:8px;
   font-size:12px; letter-spacing:.12em; text-transform:uppercase;
-  color:var(--muted); background:#fff; border:1px solid var(--line);
+  color:var(--muted); background:var(--surface); border:1px solid var(--line);
   padding:6px 10px; border-radius:999px;
 }
 
@@ -265,7 +280,7 @@ h1{ font-size:clamp(32px,6vw,56px); line-height:1.1; margin:14px 0 10px }
 /* Footer */
 .footer{
   padding:40px 0; border-top:1px solid var(--line);
-  color:var(--muted); background:#fff
+  color:var(--muted); background:var(--surface)
 }
 .footer .row{
   display:flex; flex-wrap:wrap; gap:20px; align-items:center; justify-content:space-between

--- a/src/js/common.js
+++ b/src/js/common.js
@@ -29,6 +29,7 @@ export function mountFrame(content, active = "home"){
   <div class="container row">
     <small>© ${new Date().getFullYear()} Yondev. All rights reserved.</small>
     <small><a href="impressum.html">Impressum – Datenschutz</a></small>
+    <button class="btn theme-toggle" type="button">Dark Mode</button>
   </div>
 </footer>
 `;
@@ -71,4 +72,23 @@ export function mountFrame(content, active = "home"){
   function handleBreakpoint(e){ if(!e.matches) closeMenu(); }
   mq.addEventListener('change', handleBreakpoint);
   handleBreakpoint(mq);
+
+  // theme toggle logic
+  const themeBtn = document.querySelector('.theme-toggle');
+  const stored = localStorage.getItem('theme');
+  const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+  const initial = stored || (prefersDark ? 'dark' : 'light');
+  setTheme(initial);
+
+  themeBtn?.addEventListener('click', () => {
+    const current = document.documentElement.getAttribute('data-theme');
+    const next = current === 'dark' ? 'light' : 'dark';
+    setTheme(next);
+    localStorage.setItem('theme', next);
+  });
+
+  function setTheme(theme){
+    document.documentElement.setAttribute('data-theme', theme);
+    if(themeBtn) themeBtn.textContent = theme === 'dark' ? 'Light Mode' : 'Dark Mode';
+  }
 }


### PR DESCRIPTION
## Summary
- add theme variables and dark mode palette
- include theme switcher in footer
- persist user preference

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a36fe101908321b78c49cb5ea953b4