### PR TITLE
Refine workflow section and stack services vertically

### DIFF
--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -205,10 +205,63 @@ h1{ font-size:clamp(32px,6vw,56px); line-height:1.1; margin:14px 0 10px }
   margin:0 0 20px; padding-bottom:10px;
   border-bottom:3px solid var(--accent); display:inline-block
 }
+.text-banner{
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  text-align:center;
+}
+.banner-text{
+  margin:0;
+  font-size:clamp(24px,4vw,48px);
+  font-weight:700;
+  background:linear-gradient(135deg, var(--accent), var(--primary));
+  -webkit-background-clip:text;
+  -webkit-text-fill-color:transparent;
+}
 .grid{ display:grid; gap:20px }
 .grid-3{ grid-template-columns:repeat(3,1fr) }
 .grid-2{ grid-template-columns:repeat(2,1fr) }
 @media (max-width:900px){ .grid-3,.grid-2{grid-template-columns:1fr} }
+
+.service-block{
+  width:100%;
+  padding:80px 0;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  text-align:center;
+  animation:fade-in-up .8s ease both;
+}
+.service-block:nth-of-type(odd){ background:var(--surface) }
+.service-block .container{
+  display:flex;
+  flex-direction:column;
+  align-items:center;
+}
+.service-block h2{
+  margin:0 0 20px;
+  border:none;
+  font-size:clamp(32px,5vw,56px);
+}
+.service-block ul{
+  list-style:none;
+  padding:0;
+  margin:0;
+  max-width:800px;
+}
+.service-block li{
+  margin:16px 0;
+  font-size:clamp(18px,2vw,24px);
+}
+.service-block li strong{
+  display:block;
+  font-size:clamp(20px,2.5vw,28px);
+}
+@keyframes fade-in-up{
+  from{opacity:0; transform:translateY(30px);}
+  to{opacity:1; transform:translateY(0);}
+}
 
 .card{
   background:var(--surface);

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -25,30 +25,11 @@ const content = `
   </div>
 </section>
 
-<!-- Organize: photo covered by fade overlay with ONLY the given text (bigger, centered, normal weight) -->
-<section class="section" id="workflow">
+<!-- Curate section with big text and no background image -->
+<section class="section text-banner" id="workflow">
   <div class="container">
     <h2>Curate A Better Workflow</h2>
-
-    <figure class="organize-figure">
-      <img src="src/assets/images/TimeFrontKennyEliason-min.jpg" alt="Organized content with quick edits" loading="lazy" />
-      <figcaption class="visually-hidden">Organize — structure that makes edits easy</figcaption>
-
-      <!-- Center the overlay content both vertically & horizontally -->
-      <div class="organize-overlay" style="align-items:center; justify-content:center;">
-        <div class="organize-overlay-content" style="max-width:900px; text-align:center; align-items:center;">
-          <p class="sub" style="
-            margin:0;
-            font-weight:400;            /* normal weight (unbolded) */
-            font-size:clamp(20px, 3.2vw, 40px);
-            line-height:1.25;
-          ">
-            At YonDev, we streamline your business operations with smart organisation tools that save time and reduce stress.
-            Focus on your mission. We'll handle the digital housekeeping.
-          </p>
-        </div>
-      </div>
-    </figure>
+    <p class="banner-text">At YonDev, we streamline your business operations with smart organisation tools that save time and reduce stress. Focus on your mission. We'll handle the digital housekeeping.</p>
   </div>
 </section>
 

--- a/src/js/services.js
+++ b/src/js/services.js
@@ -2,15 +2,34 @@
 import { mountFrame } from './common.js';
 
 const content = `
-<section class="section">
+<section class="service-block">
   <div class="container">
-    <h2>Services</h2>
-    <div class="grid grid-3">
-      <article class="card"><h3>Landing Pages</h3><p>High‑converting, fast‑loading pages with clear messaging.</p></article>
-      <article class="card"><h3>Business Websites</h3><p>Multi‑page sites with SEO basics and simple content management.</p></article>
-      <article class="card"><h3>Lightweight Web Apps</h3><p>Tailored tools and dashboards to cut busywork.</p></article>
-    </div>
+    <h2>Business Websites</h2>
+    <ul>
+      <li><strong>Landing Pages</strong> High-converting, fast-loading pages with clear messaging.</li>
+      <li><strong>Dynamic Sites</strong> Multi-page experiences that grow with your business.</li>
+      <li><strong>Outreach Forms</strong> Simple forms that feed inquiries straight to your inbox.</li>
+    </ul>
   </div>
-</section>`;
+</section>
+<section class="service-block">
+  <div class="container">
+    <h2>Social Media Presence</h2>
+    <ul>
+      <li><strong>Social Media</strong> Consistent content and scheduling that keeps your brand visible.</li>
+      <li><strong>Google Business Profile</strong> Optimised listings that help local customers find you.</li>
+    </ul>
+  </div>
+</section>
+<section class="service-block">
+  <div class="container">
+    <h2>Digital Marketing</h2>
+    <ul>
+      <li><strong>SEO</strong> Keyword-focused content that climbs search rankings.</li>
+      <li><strong>Emails</strong> Targeted campaigns that turn subscribers into clients.</li>
+    </ul>
+  </div>
+</section>
+`;
 
 mountFrame(content, "services");


### PR DESCRIPTION
## Summary
- Replace workflow image with large gradient text banner
- Rebuild services page into stacked full-width sections with descriptions
- Add supporting styles for banner text and service block animations

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a79221c32083219c889852c30a65fa