### PR TITLE
Swap service section colors and fix hero scroll

### DIFF
--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -255,12 +255,12 @@ h1{ font-size:clamp(32px,6vw,56px); line-height:1.1; margin:14px 0 10px }
   justify-content:center;
   text-align:center;
   animation:fade-in-up .8s ease both;
-  background:#000;
-  color:#fff;
-}
-.service-block:nth-of-type(even){
   background:linear-gradient(135deg,var(--accent),#ffb020);
   color:#111;
+}
+.service-block:nth-of-type(even){
+  background:#000;
+  color:#fff;
 }
 .service-block .container{
   display:flex;

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -83,9 +83,3 @@ mountFrame(content, 'home');
 document.querySelectorAll('.card').forEach(card => {
   card.addEventListener('click', () => card.classList.toggle('expanded'));
 });
-
-const hero = document.querySelector('.hero.hero-filled');
-window.addEventListener('scroll', () => {
-  const offset = window.pageYOffset * 0.5;
-  if(hero) hero.style.backgroundPosition = `center calc(50% + ${offset}px)`;
-});


### PR DESCRIPTION
## Summary
- invert service block background colors so first and third are accent and second is dark
- remove parallax scroll script so hero background stays fixed

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a82592bb688321bd23dfedc6851c7b