### PR TITLE
Simplify services page layout

### DIFF
--- a/services.html
+++ b/services.html
@@ -6,7 +6,6 @@
   <title>Yondev: Build Better</title>
   <link rel="icon" href="src/assets/images/favicon.ico" type="image/x-icon" />
   <link rel="stylesheet" href="src/assets/css/style.css" />
-  <link rel="stylesheet" href="src/assets/css/blob-sections.css" />
 
    <!-- Manrope (modern, legible) -->
   <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -17,7 +16,6 @@
 
 </head>
 <body>
-  <script src="src/js/blob-sections.js"></script>
   <script type="module" src="src/js/services.js"></script>
 </body>
 </html>

--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -24,24 +24,6 @@
   --hover:#1f2328;
 }
 
-[data-bubbles]{
-  --accent:#ffcf40;
-  --bg:#ffffff;
-  position:relative;
-  overflow:hidden;
-  background:var(--bg);
-}
-@media (prefers-color-scheme: dark){
-  [data-bubbles]{ --bg:#0d1117; }
-}
-[data-bubbles] canvas{
-  position:absolute;
-  inset:0;
-  width:100%;
-  height:100%;
-  display:block;
-  pointer-events:none;
-}
 
 *{box-sizing:border-box}
 html{height:100%;scroll-behavior:smooth}
@@ -253,6 +235,7 @@ h1{ font-size:clamp(32px,6vw,56px); line-height:1.1; margin:14px 0 10px }
   padding:60px 0 20px;
   text-align:center;
   background:var(--surface);
+  transition:background .3s ease,color .3s ease;
 }
 .page-title{
   margin:0;
@@ -285,10 +268,10 @@ h1{ font-size:clamp(32px,6vw,56px); line-height:1.1; margin:14px 0 10px }
   background:var(--bg);
   color:var(--text);
   position:relative;
+  transition:background .3s ease,color .3s ease;
 }
 .service-block:nth-of-type(even){
-  background:var(--bg);
-  color:var(--text);
+  background:var(--surface);
 }
 .service-block::before{display:none}
 .service-block .container{

--- a/src/js/services.js
+++ b/src/js/services.js
@@ -1,14 +1,13 @@
 
 import { mountFrame } from './common.js';
-import { initBubblesBackground } from './bubbles.js';
 
 const content = `
-<section class="page-header blobbed" data-blob="bottom" data-intensity="1" data-tilt="0" data-skew="0" data-speed="0.8" data-bubbles data-density="48" data-min-radius="4" data-max-radius="12">
+<section class="page-header">
   <div class="container">
     <h1 class="page-title">Services</h1>
   </div>
 </section>
-<section class="service-block blobbed" data-blob="top bottom" data-intensity="1" data-tilt="0" data-skew="0" data-speed="0.6">
+<section class="service-block">
   <div class="container">
     <h2>Business Websites</h2>
     <ul>
@@ -18,7 +17,7 @@ const content = `
     </ul>
   </div>
 </section>
-<section class="service-block blobbed" data-blob="top bottom" data-intensity="1" data-tilt="0.05" data-skew="0" data-speed="0.6">
+<section class="service-block">
   <div class="container">
     <h2>Social Media Presence</h2>
     <ul>
@@ -27,7 +26,7 @@ const content = `
     </ul>
   </div>
 </section>
-<section class="service-block blobbed" data-blob="top" data-intensity="1" data-tilt="0" data-skew="0" data-speed="0.6">
+<section class="service-block">
   <div class="container">
     <h2>Digital Marketing</h2>
     <ul>
@@ -39,5 +38,3 @@ const content = `
 `;
 
 mountFrame(content, "services");
-initBubblesBackground();
-initBlobSections();


### PR DESCRIPTION
## Summary
- Drop blob curves and animated bubbles from services page
- Alternate subtle backgrounds with smooth transitions for each section
- Keep service copy and emojis while supporting light/dark themes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a98f81bd1083219433e424aaa6c0e9